### PR TITLE
fix cache expiry on API module

### DIFF
--- a/src/Api/UpdateMessageApiModule.php
+++ b/src/Api/UpdateMessageApiModule.php
@@ -3,9 +3,9 @@
 namespace Liquipedia\Extension\LiquipediaMediaWikiMessages\Api;
 
 use ApiBase;
+use Liquipedia\Extension\LiquipediaMediaWikiMessages\SpecialPage\SpecialLiquipediaMediaWikiMessages;
 use MediaWiki\MediaWikiServices;
 use Wikimedia\ParamValidator\ParamValidator;
-use Liquipedia\Extension\LiquipediaMediaWikiMessages\SpecialPage\SpecialLiquipediaMediaWikiMessages;
 
 class UpdateMessageApiModule extends ApiBase {
 

--- a/src/Api/UpdateMessageApiModule.php
+++ b/src/Api/UpdateMessageApiModule.php
@@ -3,9 +3,9 @@
 namespace Liquipedia\Extension\LiquipediaMediaWikiMessages\Api;
 
 use ApiBase;
-use Liquipedia\Extension\LiquipediaMediaWikiMessages\Cache;
 use MediaWiki\MediaWikiServices;
 use Wikimedia\ParamValidator\ParamValidator;
+use Liquipedia\Extension\LiquipediaMediaWikiMessages\SpecialPage\SpecialLiquipediaMediaWikiMessages;
 
 class UpdateMessageApiModule extends ApiBase {
 
@@ -48,12 +48,7 @@ class UpdateMessageApiModule extends ApiBase {
 		$dbw->update( $tablename, [ 'messagevalue' => $value ], [ 'messagename' => $messageName ] );
 
 		// Delete from cache
-		$cache = $services->getMainWANObjectCache();
-		$cache->delete(
-			$cache->makeGlobalKey(
-				Cache::getPrefix(), md5( $messageName )
-			),
-		);
+		SpecialLiquipediaMediaWikiMessages::deleteFromCache( $messageName, $value );
 
 		$this->getResult()->addValue( null, $this->getModuleName(), [
 			'message' => $this->msg( 'liquipediamediawikimessages-api-result-success' )

--- a/src/SpecialPage/SpecialLiquipediaMediaWikiMessages.php
+++ b/src/SpecialPage/SpecialLiquipediaMediaWikiMessages.php
@@ -137,7 +137,7 @@ class SpecialLiquipediaMediaWikiMessages extends SpecialPage {
 			$tablename = 'liquipedia_mediawiki_messages';
 			try {
 				$dbw->insert( $tablename, [ 'messagename' => $reqMessage, 'messagevalue' => $reqValue ] );
-				$this->deleteFromCache( $reqMessage, $reqValue );
+				self::deleteFromCache( $reqMessage, $reqValue );
 				$this->output->addWikiTextAsContent(
 					'<div class="alert alert-success">'
 					. $this->msg( 'liquipediamediawikimessages-add-new-message-success' )->text()
@@ -336,7 +336,7 @@ class SpecialLiquipediaMediaWikiMessages extends SpecialPage {
 		$name = $dbw->select( $tablename, 'messagename', [ 'id' => $id ] )->fetchObject()->messagename;
 
 		$dbw->update( $tablename, [ 'messagevalue' => $value ], [ 'id' => $id ] );
-		$this->deleteFromCache( $name, $value );
+		self::deleteFromCache( $name, $value );
 	}
 
 	/**
@@ -348,14 +348,14 @@ class SpecialLiquipediaMediaWikiMessages extends SpecialPage {
 		$name = $dbw->select( $tablename, [ 'id' => $id ] )->fetchObject()->messagename;
 
 		$dbw->delete( $tablename, [ 'id' => $id ] );
-		$this->deleteFromCache( $name, false );
+		self::deleteFromCache( $name, false );
 	}
 
 	/**
 	 * @param string $title
 	 * @param string|false $value
 	 */
-	private function deleteFromCache( $title, $value ) {
+	public static function deleteFromCache( $title, $value ) {
 		// Remove cached value
 		$mediaWikiServices = MediaWikiServices::getInstance();
 		$messageCache = $mediaWikiServices->getMessageCache();


### PR DESCRIPTION
The API module still tried to use the old way of expiring the cache. This fixes that.