### PR TITLE
fix: add missing schema update

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -47,8 +47,8 @@
 	},
 	"Hooks": {
 		"ApiCheckCanExecute": "Main",
-		"LoadExtensionSchemaUpdates": "Schema"
-		"MessagesPreLoad": "Main",
+		"LoadExtensionSchemaUpdates": "Schema",
+		"MessagesPreLoad": "Main"
 	},
 	"SpecialPages": {
 		"LiquipediaMediaWikiMessages": {

--- a/extension.json
+++ b/extension.json
@@ -40,11 +40,15 @@
 				"LanguageFallback",
 				"DBLoadBalancer"
 			]
+		},
+		"Schema": {
+			"class": "\\Liquipedia\\Extension\\LiquipediaMediaWikiMessages\\Hooks\\SchemaHookHandler"
 		}
 	},
 	"Hooks": {
 		"ApiCheckCanExecute": "Main",
-		"MessagesPreLoad": "Main"
+		"MessagesPreLoad": "Main",
+		"LoadExtensionSchemaUpdates": "Schema"
 	},
 	"SpecialPages": {
 		"LiquipediaMediaWikiMessages": {

--- a/extension.json
+++ b/extension.json
@@ -47,8 +47,8 @@
 	},
 	"Hooks": {
 		"ApiCheckCanExecute": "Main",
-		"MessagesPreLoad": "Main",
 		"LoadExtensionSchemaUpdates": "Schema"
+		"MessagesPreLoad": "Main",
 	},
 	"SpecialPages": {
 		"LiquipediaMediaWikiMessages": {

--- a/src/Api/UpdateMessageApiModule.php
+++ b/src/Api/UpdateMessageApiModule.php
@@ -9,9 +9,6 @@ use Wikimedia\ParamValidator\ParamValidator;
 
 class UpdateMessageApiModule extends ApiBase {
 
-	/**
-	 *
-	 */
 	public function execute() {
 		$postValues = $this->getRequest()->getPostValues();
 		if ( !array_key_exists( 'messagename', $postValues ) ) {
@@ -51,7 +48,7 @@ class UpdateMessageApiModule extends ApiBase {
 		SpecialLiquipediaMediaWikiMessages::deleteFromCache( $messageName, $value );
 
 		$this->getResult()->addValue( null, $this->getModuleName(), [
-			'message' => $this->msg( 'liquipediamediawikimessages-api-result-success' )
+		'message' => $this->msg( 'liquipediamediawikimessages-api-result-success' )
 		] );
 	}
 

--- a/src/Hooks/SchemaHookHandler.php
+++ b/src/Hooks/SchemaHookHandler.php
@@ -18,7 +18,10 @@ class SchemaHookHandler implements
 		$dbName = $config->get( 'DBname' );
 		$db = $updater->getDB();
 		if ( !$db->tableExists( $dbName . '.liquipedia_mediawiki_messages', __METHOD__ ) ) {
-			$updater->addExtensionTable( 'liquipedia_mediawiki_messages', __DIR__ . '/../../sql/liquipedia_mediawiki_messages.sql' );
+			$updater->addExtensionTable(
+				'liquipedia_mediawiki_messages',
+				__DIR__ . '/../../sql/liquipedia_mediawiki_messages.sql'
+			);
 		}
 	}
 

--- a/src/Hooks/SchemaHookHandler.php
+++ b/src/Hooks/SchemaHookHandler.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Liquipedia\Extension\LiquipediaMediaWikiMessages\Hooks;
+
+use DatabaseUpdater;
+use MediaWiki\Installer\Hook\LoadExtensionSchemaUpdatesHook;
+use MediaWiki\MediaWikiServices;
+
+class SchemaHookHandler implements
+	LoadExtensionSchemaUpdatesHook
+{
+
+	/**
+	 * @param DatabaseUpdater $updater
+	 */
+	public function onLoadExtensionSchemaUpdates( $updater ) {
+		$config = MediaWikiServices::getInstance()->getMainConfig();
+		$dbName = $config->get( 'DBname' );
+		$db = $updater->getDB();
+		if ( !$db->tableExists( $dbName . '.liquipedia_mediawiki_messages', __METHOD__ ) ) {
+			$updater->addExtensionTable( 'liquipedia_mediawiki_messages', __DIR__ . '/../../sql/liquipedia_mediawiki_messages.sql' );
+		}
+	}
+
+}

--- a/src/SpecialPage/SpecialLiquipediaMediaWikiMessages.php
+++ b/src/SpecialPage/SpecialLiquipediaMediaWikiMessages.php
@@ -17,7 +17,6 @@ class SpecialLiquipediaMediaWikiMessages extends SpecialPage {
 	private $output;
 
 	/**
-	 *
 	 * @var Config
 	 */
 	private $config;
@@ -28,7 +27,6 @@ class SpecialLiquipediaMediaWikiMessages extends SpecialPage {
 	private $loadBalancer;
 
 	/**
-	 *
 	 * @param Config $config
 	 * @param ILoadBalancer $loadBalancer
 	 */


### PR DESCRIPTION
On a new environment, the follow error is being logged on update:
```
Table 'liquipedia.liquipedia_mediawiki_messages' doesn't exist
```

To mitigate that, this PR aims to add the sql to a schema handler to be loaded on update in order to create the target table.

Tested locally only.
